### PR TITLE
don't overwrite name if value exists in keyset

### DIFF
--- a/gremlinpy/gremlin.py
+++ b/gremlinpy/gremlin.py
@@ -224,7 +224,7 @@ class Gremlin(LinkList):
                     break
         elif value in self.stack_bound_params.keys():
             for n, v in self.bound_params.items():
-                if n == value:
+                if n == value and not name:
                     name = n
                     value = v
                     break

--- a/gremlinpy/gremlin.py
+++ b/gremlinpy/gremlin.py
@@ -219,7 +219,7 @@ class Gremlin(LinkList):
 
         if value in self.stack_bound_params.values():
             for n, v in self.bound_params.items():
-                if v == value:
+                if v == value and name is None:
                     name = n
                     break
         elif value in self.stack_bound_params.keys():


### PR DESCRIPTION
I'm not sure what this scenario is for in bind_param:

```
elif value in self.stack_bound_params.keys():
            for n, v in self.bound_params.items():
                if n == value:
                    name = n
                    value = v
                    break
```

apparently if we find the value in the existing keys, we give it the name n (which is also the value), and then we replace the existing value (which we now know is the same as name and n?) with the original value, and entirely lose the original value we were trying to bind?

Same issue as emehrkay/gremlinpy#2 but a corollary; when adding a parent instance, param names are being overwritten if their value exists in the parent param keyset, which is sometimes does so I'm adding a check to only do this if there isn't already a name assigned -- but it strikes me that users could potentially lose their original value in the case where an original name is not supplied.
